### PR TITLE
Update to latest Rust.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! such as application structure.
 
 use std::cell::RefCell;
-use std::intrinsics::TypeId;
+use std::any::TypeId;
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{ Occupied, Vacant };
 use std::ops::{ Deref, DerefMut };


### PR DESCRIPTION
`std::intrinsics::TypeId` stabilized and is now available at `std::any::TypeId`.

Waiting for Travis.