### PR TITLE
Fix #98 - Allow mutable transmutes.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 #![deny(missing_docs)]
 #![feature(core)]
+#![allow(mutable_transmutes)]
+
 
 //! A library for setting current values for stack scope,
 //! such as application structure.


### PR DESCRIPTION
Might want to consider using an UnsafeCell as the warning notes, but if it worked before it should still work now. Some discussion here: https://github.com/rust-lang/rust/issues/14525.